### PR TITLE
Add option to use or not table name on query filter

### DIFF
--- a/config/landlord.php
+++ b/config/landlord.php
@@ -34,6 +34,6 @@ return [
     |
     */
 
-    'query_with_table_name' => false,
+    'query_with_table_name' => true,
 
 ];

--- a/config/landlord.php
+++ b/config/landlord.php
@@ -20,4 +20,20 @@ return [
 
     'default_tenant_columns' => ['company_id'],
 
+    /*
+    |--------------------------------------------------------------------------
+    | Query using table name
+    |--------------------------------------------------------------------------
+    |
+    | When building the tenant query filter, it´s common to use the table name
+    | with the column, using the dot notation. At some situations it´s better
+    | to use only the column name.
+    |
+    | If you are using a database as MongoDB, set this option to false. Default 
+    | is true.
+    |
+    */
+
+    'query_with_table_name' => false,
+
 ];

--- a/src/Landlord.php
+++ b/src/Landlord.php
@@ -90,7 +90,11 @@ class Landlord implements Scope
         }
 
         foreach ($this->getModelTenants($model) as $tenantColumn => $tenantId) {
-            $builder->where($model->getTable() . '.' . $tenantColumn, '=', $tenantId);
+            if (config('landlord.query_with_table_name')) {
+                $builder->where($model->getTable() . '.' . $tenantColumn, '=', $tenantId);
+            } else {
+                $builder->where($tenantColumn, '=', $tenantId);
+            }
         }
     }
 


### PR DESCRIPTION
I was having problems to use the package with MongoDB and jenssegers/mongodb driver. The problem was that when the query with where by tenant id is build, the table name  is added always. 

This PR add a config named `query_with_table_name` set as default to true, to keep the original behavior. When this option is set to false, than table name is not used, only the column name.