### PR TITLE
Adds the ability to include records with a null tenant ID field

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,15 @@ ExampleModel::find(2);
 >
 > Landlord will catch those exceptions, and re-throw them as `ModelNotFoundForTenantException`, to help you out :)
 
+If you need to query including records with a null tenant column, for exampl if you have default categories that can be added to by a tenant, you can use `includeNull()`:
+
+```php
+// Will include results with null tenant ID fields
+ExampleModel::includeNull()->all()
+
+ExampleModel::includeNull()->find(1)
+```
+
 If you need to query across all tenants, you can use `allTenants()`:
 
 ```php

--- a/src/BelongsToTenants.php
+++ b/src/BelongsToTenants.php
@@ -57,6 +57,16 @@ trait BelongsToTenants
     }
 
     /**
+     * Returns a current Model with tenant scopes updated to include null tenants
+     *
+     * @return Model|void
+     */
+    public static function includeNull()
+    {
+        return static::$landlord->includeNull(new static());
+    }
+
+    /**
      * Override the default findOrFail method so that we can re-throw
      * a more useful exception. Otherwise it can be very confusing
      * why queries don't work because of tenant scoping issues.

--- a/src/TenantManager.php
+++ b/src/TenantManager.php
@@ -129,6 +129,31 @@ class TenantManager
     }
 
     /**
+     * Get a new Model instance with tenant scopes applied to include null.
+     *
+     * @param Model $model
+     *
+     * @return Model|void
+     */
+    public function includeNull(Model $model)
+    {
+        if (!$this->enabled) {
+            return $model;
+        }
+
+        $model->newQuery()->withoutGlobalScopes($this->tenants->keys()->toArray());
+
+        $this->modelTenants($model)->each(function ($id, $tenant) use ($model) {
+            $model->addGlobalScope($tenant, function (Builder $builder) use ($tenant, $id, $model) {
+                $builder->where($model->getTable().'.'.$tenant, '=', $id);
+                $builder->orWhereNull($model->getTable().'.'.$tenant);
+            });
+        });
+
+        return $model;
+    }
+
+    /**
      * Get a new Eloquent Builder instance without any of the tenant scopes applied.
      *
      * @param Model $model


### PR DESCRIPTION
Adds the ability to include records with a null tenant ID field in queries.

For example if there is a list of base system categories that can be added to by the users(s) of an individual tenant for their sole use.

Re-sets the global scope queries to add 'OR WHERE tenant_field_id IS NULL' 