### PR TITLE
Allow for multiple Tenant ID's to be included

### DIFF
--- a/src/TenantManager.php
+++ b/src/TenantManager.php
@@ -123,7 +123,11 @@ class TenantManager
 
         $this->modelTenants($model)->each(function ($id, $tenant) use ($model) {
             $model->addGlobalScope($tenant, function (Builder $builder) use ($tenant, $id, $model) {
-                $builder->where($model->getQualifiedTenant($tenant), '=', $id);
+                if (is_array($id)) {
+                    $builder->whereIn($model->getQualifiedTenant($tenant), $id);
+                } else {
+                    $builder->where($model->getQualifiedTenant($tenant), '=', $id);
+                }
             });
         });
     }


### PR DESCRIPTION
In some cases, we've seen the requirement for allowing multiple tenants to be included on the same platform/instance.

This modification should not have any implications on existing implementations, and should only extend the current functionality.

Since it's already allowed to use addTenants with an array, it makes sense, that it should also scope by multiple ID's.

Could be extended to allow for a collection object, instead of only arrays if it has potential.