### PR TITLE
Update illuminate to work with Laravel 5.4.*

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,12 +16,12 @@
     ],
     "require": {
         "php": ">=5.6.0",
-        "illuminate/support": "5.2.*|5.3.*"
+        "illuminate/support": "5.2.*|5.3.*|5.4.*"
     },
     "require-dev": {
         "mockery/mockery": "~0.9",
         "phpunit/phpunit": "5.5.*",
-        "laravel/framework": "5.2.*|5.3.*"
+        "laravel/framework": "5.2.*|5.3.*|5.4.*"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Hello @HipsterJazzbo ! I've updated the composer.json so we can use it Laravel 5.4