### PR TITLE
Added a hook to modify the query builder for special use cases

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,12 +16,12 @@
     ],
     "require": {
         "php": ">=5.6.0",
-        "illuminate/support": "5.2.*|5.3.*|5.4.*"
+        "illuminate/support": "5.2.*|5.3.*|5.4.*|5.5.*"
     },
     "require-dev": {
         "mockery/mockery": "~0.9",
         "phpunit/phpunit": "5.5.*",
-        "laravel/framework": "5.2.*|5.3.*|5.4.*"
+        "laravel/framework": "5.2.*|5.3.*|5.4.*|5.5.*"
     },
     "autoload": {
         "psr-4": {

--- a/src/TenantManager.php
+++ b/src/TenantManager.php
@@ -147,6 +147,10 @@ class TenantManager
                 }
 
                 $builder->where($model->getQualifiedTenant($tenant), '=', $id);
+                
+                if (method_exists($model, 'applyExtraTenantScopes')) {
+                    $model->applyExtraTenantScopes($builder, $tenant, $id);
+                }
             });
         });
     }
@@ -169,6 +173,10 @@ class TenantManager
                     }
 
                     $builder->where($model->getQualifiedTenant($tenant), '=', $id);
+                    
+                    if (method_exists($model, 'applyExtraTenantScopes')) {
+                        $model->applyExtraTenantScopes($builder, $tenant, $id);
+                    }
                 });
             });
         });


### PR DESCRIPTION
Adds the ability to call `applyExtraTenantScopes` which allows you to modify the query builder.

This is extremely useful for when you need to apply extra logic, for example

`where tenant_id = 1 or user_type == 'super_admin'`

---

We found ourself in a situation where our client required a "super user" mode which gave him a separate subdomain to access the application through, and engage with all the tenants.

This posed an issue as when you then view the super users engagement from one of the tentants, as the super user did not exist within their scope, their interactions would never display.

By allowing access to the builder we can modify it when needed for special situations. for example

```php
class User {

    use BelongsToTenants;

    public function applyExtraTenantScopes($builder, $tenant, $id)
    {
        $builder->orWhere('users.is_super_user', 1);
    }
}

````