### PR TITLE
Fix querying allTenants when trait on model was not booted yet

### DIFF
--- a/src/BelongsToTenants.php
+++ b/src/BelongsToTenants.php
@@ -66,7 +66,8 @@ trait BelongsToTenants
      */
     public static function allTenants()
     {
-        return static::$landlord->newQueryWithoutTenants(new static());
+        $model = new static();
+        return static::$landlord->newQueryWithoutTenants($model);
     }
 
     /**

--- a/tests/LandlordTest.php
+++ b/tests/LandlordTest.php
@@ -8,6 +8,24 @@ use PHPUnit\Framework\TestCase;
 
 class LandlordTest extends TestCase
 {
+    public function testApplyScopesQueryAllTenants()
+    {
+        app()->bind(TenantManager::class, function() {
+            $manager = \Mockery::mock(TenantManager::class);
+            $manager->shouldReceive('newQueryWithoutTenants')->andReturn([]);
+            $manager->shouldReceive('applyTenantScopes');
+            return $manager;
+        });
+
+        $landlord = new TenantManager();
+
+        $landlord->addTenant('tenant_a_id', 1);
+
+        $landlord->addTenant('tenant_b_id', 2);
+
+        $this->assertEquals([], ModelStub::allTenants());
+    }
+
     public function testTenantsWithStrings()
     {
         $landlord = new TenantManager();


### PR DESCRIPTION
- Although a new model is created before, the `static::$landlord` instance is still null at the moment when it should call `newQueryWithoutTenants`. I don’t know if this is a PHP bug but it works when moving the creation of the model to the previous line
- This issue only arises when no model was created or queried before calling `allTenants`.
- Therefore the test only works as the first test in the class because the trait is only booted once per test session and the `static::$landlord` stays always initialized. 