### PR TITLE
Add disabledFor to disable for duration of callable

### DIFF
--- a/src/TenantManager.php
+++ b/src/TenantManager.php
@@ -55,6 +55,22 @@ class TenantManager
     }
 
     /**
+     * Disable the scope for the duration of a given method.
+     *
+     * @param callable $callback
+     *
+     * @return mixed|void
+     */
+    public function disabledFor(callable $method)
+    {
+        $this->disable();
+
+        return tap($method(), function () {
+            $this->enable();
+        });
+    }
+
+    /**
      * Add a tenant to scope by.
      *
      * @param string|Model $tenant


### PR DESCRIPTION
This PR adds a new `disabledFor` method which disables the Landlord scope for the duration of a callable...

```php
Landlord::disabledFor(function () {
    // The scope is now disabled.
});

// At this point, the Landlord scope is now re-enabled.
```