### PR TITLE
Updated compatibility to Laravel 5.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,12 +16,12 @@
     ],
     "require": {
         "php": ">=5.6.0",
-        "illuminate/support": "5.2.*|5.3.*|5.4.*|5.5.*"
+        "illuminate/support": "5.2.*|5.3.*|5.4.*|5.5.*|5.6.*"
     },
     "require-dev": {
-        "mockery/mockery": "~0.9",
-        "phpunit/phpunit": "5.5.*|6.0.*",
-        "laravel/framework": "5.2.*|5.3.*|5.4.*|5.5.*"
+        "mockery/mockery": "~0.9|~1.0",
+        "phpunit/phpunit": "5.5.*|6.0.*|7.0.*",
+        "laravel/framework": "5.2.*|5.3.*|5.4.*|5.5.*|5.6.*"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
The [upgrade guide](https://laravel.com/docs/5.6/upgrade)  for L5.6 doesn't seem to introduce any breaking changes.