### PR TITLE
Allow Laravel 5.7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,12 +16,12 @@
     ],
     "require": {
         "php": ">=5.6.0",
-        "illuminate/support": "5.2.*|5.3.*|5.4.*|5.5.*|5.6.*"
+        "illuminate/support": "5.2.*|5.3.*|5.4.*|5.5.*|5.6.*|5.7.*"
     },
     "require-dev": {
         "mockery/mockery": "~0.9|~1.0",
         "phpunit/phpunit": "5.5.*|6.0.*|7.0.*",
-        "laravel/framework": "5.2.*|5.3.*|5.4.*|5.5.*|5.6.*"
+        "laravel/framework": "5.2.*|5.3.*|5.4.*|5.5.*|5.6.*|5.7.*"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
I have done a quick test with this on a Laravel 5.7 install and it seems to work.

@HipsterJazzbo This should be ready for merge to allow Laravel 5.7