### PR TITLE
Add model ids to ModelNotFoundForTenantException

### DIFF
--- a/src/BelongsToTenants.php
+++ b/src/BelongsToTenants.php
@@ -88,7 +88,7 @@ trait BelongsToTenants
         } catch (ModelNotFoundException $e) {
             // If it DOES exist, just not for this tenant, throw a nicer exception
             if (!is_null(static::allTenants()->find($id, $columns))) {
-                throw (new ModelNotFoundForTenantException())->setModel(get_called_class());
+                throw (new ModelNotFoundForTenantException())->setModel(get_called_class(), $id);
             }
 
             throw $e;

--- a/src/Exceptions/ModelNotFoundForTenantException.php
+++ b/src/Exceptions/ModelNotFoundForTenantException.php
@@ -3,6 +3,7 @@
 namespace HipsterJazzbo\Landlord\Exceptions;
 
 use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Support\Arr;
 
 class ModelNotFoundForTenantException extends ModelNotFoundException implements TenantExceptionInterface
 {
@@ -15,6 +16,7 @@ class ModelNotFoundForTenantException extends ModelNotFoundException implements 
     public function setModel($model, $ids = [])
     {
         $this->model = $model;
+        $this->ids = Arr::wrap($ids);
         $this->message = "No query results for model [{$model}] when scoped by tenant.";
 
         return $this;


### PR DESCRIPTION
It is now not possible to extract the ids from the exception. That's why I can't return a (custom translated) response with an id.